### PR TITLE
fix: add missing /health endpoint for Railway health checks

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -5,6 +5,11 @@ import { Hono } from "hono";
 
 const app = new Hono();
 
+// Health endpoint for Railway health checks
+app.get("/health", (c) => {
+  return c.json({ status: "ok", timestamp: Date.now() });
+});
+
 // GraphQL API — auto-generated from schema
 app.use("/graphql", graphql({ db, schema }));
 


### PR DESCRIPTION
## What
- Add missing  endpoint to 
- Returns simple JSON status response

## Why  
- Railway deployment config references  endpoint for health checks
- Dockerfile also has health check pointing to 
- This endpoint was missing, potentially causing deployment health check failures
- Deploy failures may have been due to health checks failing, not just re-sync timeout

## Testing
- ✅ 21:13:05.514 INFO  Wrote file "ponder-env.d.ts"
21:13:05.516 WARN  Started shutdown sequence succeeds
- ✅ Both  and  endpoints remain intact
- ✅ New  endpoint returns 

This should fix the Railway deployment failures and trigger a fresh deploy.